### PR TITLE
fix simple doc bug, add TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ func main() {
 }
 
 func RegisterHandlers(bot *ircx.Bot) {
-	bot.AddCallback(irc.RPL_WELCOME, ircx.Callback{Handler: irc.HandlerFunc(RegisterConnect)})
-	bot.AddCallback(irc.PING, ircx.Callback{Handler: irc.HandlerFunc(PingHandler)})
+	bot.AddCallback(irc.RPL_WELCOME, ircx.Callback{Handler: ircx.HandlerFunc(RegisterConnect)})
+	bot.AddCallback(irc.PING, ircx.Callback{Handler: ircx.HandlerFunc(PingHandler)})
 }
 
 func RegisterConnect(s ircx.Sender, m *irc.Message) {

--- a/tls_test.go
+++ b/tls_test.go
@@ -1,0 +1,83 @@
+package ircx
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+)
+
+func TestTLSConnect(t *testing.T) {
+	// Generate self-signed certificate for mock server
+
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(1234),
+		Subject: pkix.Name{
+			Country:            []string{"USA"},
+			Organization:       []string{"ircxtest"},
+			OrganizationalUnit: []string{"test"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		SubjectKeyId:          []byte{1, 2, 3, 4, 5},
+		BasicConstraintsValid: true,
+		IsCA:        true,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+	}
+
+	priv, _ := rsa.GenerateKey(rand.Reader, 1024)
+	pub := &priv.PublicKey
+
+	ca_b, err := x509.CreateCertificate(rand.Reader, ca, ca, pub, priv)
+	if err != nil {
+		t.Fatalf("error generating self-cert: %v", err)
+	}
+
+	cert := tls.Certificate{
+		Certificate: [][]byte{ca_b},
+		PrivateKey:  priv,
+	}
+
+	// prep config for mock server
+	serverConfig := tls.Config{Certificates: []tls.Certificate{cert}}
+
+	l, err := tls.Listen("tcp", "127.0.0.1:0", &serverConfig)
+	if err != nil {
+		t.Fatalf("Wanted listener, got err: %v", err)
+	}
+
+	// prep bot/bot config
+	botConfig := &tls.Config{InsecureSkipVerify: true}
+	b := WithLoginTLS(l.Addr().String(), "test-bot", "test-user", "test-password", botConfig)
+
+	not := make(chan string)
+	go echoHelper(l, not)
+	err = b.Connect()
+	if err != nil {
+		t.Fatalf("error connecting to mock TLS server: %v", err)
+	}
+
+	// We should get back the connect info. If 500ms has happened and we haven't gotten anything
+	// we're either not connected right, or all of the data has been sent.
+	data := []string{}
+	for {
+		select {
+		case d := <-not:
+			data = append(data, d)
+		case <-time.After(250 * time.Millisecond):
+			goto DONE
+		}
+	}
+DONE:
+	d := b.connectMessages()
+	for k, v := range d {
+		if v.String() != data[k] {
+			t.Fatalf("Should have recieved %s, got %s", d[k], v)
+		}
+	}
+}


### PR DESCRIPTION
Fixes issue #3
Also, as far as TLS, the test I added (which mirrors TestSendsData), succeeds, but, interestingly, if I add a test that mirrors TestConnect, it loops infinitely. Maybe something to do with a bug in dummyHelper?  Haven't had time to look into it. Bot connects to Freenode using TLS using a &tls.Config{}, so it looks like the code works. Let me know if you want to do further testing and I can take a look.