### PR TITLE
Redo config methods to be more sane

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ func init() {
 }
 
 func main() {
-	bot := ircx.Classic(*server, *name)
+	bot := ircx.New(*server, *name)
 	if err := bot.Connect(); err != nil {
 		log.Panicln("Unable to dial IRC Server ", err)
 	}

--- a/bot.go
+++ b/bot.go
@@ -11,29 +11,31 @@ import (
 )
 
 type Bot struct {
-	Server       string
-	OriginalName string
-	Password     string
-	User         string
-	Options      map[string]bool
-	Data         chan *irc.Message
-	tlsConfig    *tls.Config
-	sender       ServerSender
-	callbacks    map[string][]Callback
-	reader       *irc.Decoder
-	writer       *irc.Encoder
-	conn         net.Conn
-	tries        float64
+	// required options
+	server string
+	name   string
+
+	// optional params
+	password  string
+	user      string
+	tlsConfig *tls.Config
+
+	events    chan *irc.Message
+	sender    ServerSender
+	callbacks map[string][]Callback
+	reader    *irc.Decoder
+	writer    *irc.Encoder
+	conn      net.Conn
+	tries     float64
+	connected bool
 }
 
-func NewBot(f ...func(*Bot)) *Bot {
-	defaultOpts := map[string]bool{
-		"rejoin":    true,
-		"connected": true,
-	}
+func New(server, name string, f ...func(*Bot)) *Bot {
 	b := &Bot{
-		Options:   defaultOpts,
-		Data:      make(chan *irc.Message),
+		server:    server,
+		name:      name,
+		connected: false,
+		events:    make(chan *irc.Message),
 		callbacks: make(map[string][]Callback),
 		tries:     0,
 	}
@@ -43,64 +45,14 @@ func NewBot(f ...func(*Bot)) *Bot {
 	return b
 }
 
-// Classic creates an instance of ircx poised to connect to the given server
-// with the given IRC name.
-func Classic(server string, name string) *Bot {
-	configFunc := func(b *Bot) {
-		b.Server = server
-		b.OriginalName = name
-		b.User = name
-	}
-	return NewBot(configFunc)
-}
-
-func WithLogin(server string, name string, user string, password string) *Bot {
-	configFunc := func(b *Bot) {
-		b.Server = server
-		b.OriginalName = name
-		b.User = user
-		b.Password = password
-	}
-	return NewBot(configFunc)
-}
-
-// WithTLS creates an instance of ircx poised to connect to the given server
-// using TLS with the given IRC name.
-func WithTLS(server string, name string, tlsConfig *tls.Config) *Bot {
-	if tlsConfig == nil {
-		tlsConfig = &tls.Config{}
-	}
-	configFunc := func(b *Bot) {
-		b.Server = server
-		b.OriginalName = name
-		b.User = name
-		b.tlsConfig = tlsConfig
-	}
-	return NewBot(configFunc)
-}
-
-func WithLoginTLS(server string, name string, user string, password string, tlsConfig *tls.Config) *Bot {
-	if tlsConfig == nil {
-		tlsConfig = &tls.Config{}
-	}
-	configFunc := func(b *Bot) {
-		b.Server = server
-		b.OriginalName = name
-		b.User = user
-		b.Password = password
-		b.tlsConfig = tlsConfig
-	}
-	return NewBot(configFunc)
-}
-
 // Connect attempts to connect to the given IRC server
 func (b *Bot) Connect() error {
 	var conn net.Conn
 	var err error
 	if b.tlsConfig == nil {
-		conn, err = net.Dial("tcp", b.Server)
+		conn, err = net.Dial("tcp", b.server)
 	} else {
-		conn, err = tls.Dial("tcp", b.Server, b.tlsConfig)
+		conn, err = tls.Dial("tcp", b.server, b.tlsConfig)
 	}
 	if err != nil {
 		return err
@@ -115,32 +67,29 @@ func (b *Bot) Connect() error {
 			return err
 		}
 	}
-	log.Println("Connected to", b.Server)
+	log.Println("Connected to", b.server)
 	b.tries = 0
-	go b.ReadLoop()
+	b.connected = true
+	go b.readLoop()
 	return nil
 }
 
-// Reconnect checks to make sure we want to, and then attempts to
-// reconnect to the server
+// Reconnect
 func (b *Bot) Reconnect() {
-	data, ok := b.Options["connected"]
-	if data || !ok {
+	if b.connected {
 		b.conn.Close()
 		for err := b.Connect(); err != nil; err = b.Connect() {
 			duration := time.Duration(math.Pow(2.0, b.tries)*200) * time.Millisecond
-			log.Printf("Unable to connect to %s, waiting %s", b.Server, duration.String())
+			log.Printf("Unable to connect to %s, waiting %s", b.server, duration.String())
 			time.Sleep(duration)
 			b.tries++
 		}
-	} else {
-		close(b.Data)
 	}
 }
 
 // ReadLoop sets a timeout of 300 seconds, and then attempts to read
 // from the IRC server. If there is an error, it calls Reconnect
-func (b *Bot) ReadLoop() {
+func (b *Bot) readLoop() {
 	for {
 		b.conn.SetDeadline(time.Now().Add(300 * time.Second))
 		msg, err := b.reader.Decode()
@@ -149,6 +98,6 @@ func (b *Bot) ReadLoop() {
 			b.Reconnect()
 			return
 		}
-		b.Data <- msg
+		b.events <- msg
 	}
 }

--- a/bot_test.go
+++ b/bot_test.go
@@ -4,76 +4,23 @@ import (
 	"bufio"
 	"fmt"
 	"net"
-	"reflect"
 	"testing"
 	"time"
 )
 
 func TestNewBot(t *testing.T) {
 	config := func(b *Bot) {
-		b.Server = "irc.example.org"
-		b.OriginalName = "test-bot"
-		b.User = "test-user"
+		b.user = "test-user"
 	}
-	wantOpts := map[string]bool{
-		"rejoin":    true,
-		"connected": true,
+	b := New("irc.example.org", "test-bot", config)
+	if b.server != "irc.example.org" {
+		t.Fatalf("Wanted server %s, got %s", "irc.example.org", b.server)
 	}
-	b := NewBot(config)
-	if b.Server != "irc.example.org" {
-		t.Fatalf("Wanted server %s, got %s", "irc.example.org", b.Server)
+	if b.name != "test-bot" {
+		t.Fatalf("Wanted name %s, got %s", "test-bot", b.name)
 	}
-	if b.OriginalName != "test-bot" {
-		t.Fatalf("Wanted name %s, got %s", "test-bot", b.OriginalName)
-	}
-	if b.User != "test-user" {
-		t.Fatalf("Wanted user %s, got %s", "test-user", b.User)
-	}
-	if !reflect.DeepEqual(b.Options, wantOpts) {
-		t.Fatalf("Wanted config options %s, got %s", wantOpts, b.Options)
-	}
-}
-
-func TestClassicHelper(t *testing.T) {
-	b := Classic("irc.example.org", "test-bot")
-	wantOpts := map[string]bool{
-		"rejoin":    true,
-		"connected": true,
-	}
-	if b.Server != "irc.example.org" {
-		t.Fatalf("Wanted server %s, got %s", "irc.example.org", b.Server)
-	}
-	if b.OriginalName != "test-bot" {
-		t.Fatalf("Wanted name %s, got %s", "test-bot", b.OriginalName)
-	}
-	if b.User != "test-bot" {
-		t.Fatalf("Wanted user %s, got %s", "test-bot", b.User)
-	}
-	if !reflect.DeepEqual(b.Options, wantOpts) {
-		t.Fatalf("Wanted config options %s, got %s", wantOpts, b.Options)
-	}
-}
-
-func TestPasswordHelper(t *testing.T) {
-	b := WithLogin("irc.example.org", "test-bot", "test-user", "test-password")
-	wantOpts := map[string]bool{
-		"rejoin":    true,
-		"connected": true,
-	}
-	if b.Server != "irc.example.org" {
-		t.Fatalf("Wanted server %s, got %s", "irc.example.org", b.Server)
-	}
-	if b.OriginalName != "test-bot" {
-		t.Fatalf("Wanted name %s, got %s", "test-bot", b.OriginalName)
-	}
-	if b.User != "test-user" {
-		t.Fatalf("Wanted user %s, got %s", "test-user", b.User)
-	}
-	if b.Password != "test-password" {
-		t.Fatalf("Wanted password %s, got %s", "test-password", b.Password)
-	}
-	if !reflect.DeepEqual(b.Options, wantOpts) {
-		t.Fatalf("Wanted config options %s, got %s", wantOpts, b.Options)
+	if b.user != "test-user" {
+		t.Fatalf("Wanted user %s, got %s", "test-user", b.user)
 	}
 }
 
@@ -83,7 +30,7 @@ func TestConnect(t *testing.T) {
 		t.Fatalf("Wanted listener, got err: %v", err)
 	}
 
-	b := Classic(l.Addr().String(), "test-bot")
+	b := New(l.Addr().String(), "test-bot")
 
 	not := make(chan struct{})
 	go dummyHelper(l, not)
@@ -107,7 +54,7 @@ func TestSendsData(t *testing.T) {
 		t.Fatalf("Wanted listener, got err: %v", err)
 	}
 
-	b := WithLogin(l.Addr().String(), "test-bot", "test-user", "test-password")
+	b := New(l.Addr().String(), "test-bot", WithLogin("test-user", "test-password"))
 
 	not := make(chan string)
 	go echoHelper(l, not)
@@ -142,7 +89,7 @@ func TestSendsDataWithPassword(t *testing.T) {
 		t.Fatalf("Wanted listener, got err: %v", err)
 	}
 
-	b := Classic(l.Addr().String(), "test-bot")
+	b := New(l.Addr().String(), "test-bot")
 
 	not := make(chan string)
 	go echoHelper(l, not)
@@ -177,7 +124,7 @@ func TestReconnect(t *testing.T) {
 		t.Fatalf("Wanted listener, got err: %v", err)
 	}
 
-	b := Classic(l.Addr().String(), "test-bot")
+	b := New(l.Addr().String(), "test-bot")
 
 	not := make(chan struct{})
 	go dcHelper(l, not)

--- a/callbacks.go
+++ b/callbacks.go
@@ -33,7 +33,7 @@ func (b *Bot) AddCallback(value string, c Callback) {
 func (b *Bot) CallbackLoop() {
 	for {
 		select {
-		case msg, ok := <-b.Data:
+		case msg, ok := <-b.events:
 			if ok {
 				b.messageCallback(msg)
 			} else {

--- a/config.go
+++ b/config.go
@@ -1,0 +1,18 @@
+package ircx
+
+import "crypto/tls"
+
+type Config func(*Bot)
+
+func WithLogin(user, pass string) Config {
+	return func(b *Bot) {
+		b.user = user
+		b.password = pass
+	}
+}
+
+func WithTLS(config *tls.Config) Config {
+	return func(b *Bot) {
+		b.tlsConfig = config
+	}
+}

--- a/tls_test.go
+++ b/tls_test.go
@@ -53,7 +53,7 @@ func TestTLSConnect(t *testing.T) {
 
 	// prep bot/bot config
 	botConfig := &tls.Config{InsecureSkipVerify: true}
-	b := WithLoginTLS(l.Addr().String(), "test-bot", "test-user", "test-password", botConfig)
+	b := New(l.Addr().String(), "test-bot", WithLogin("test-user", "test-password"), WithTLS(botConfig))
 
 	not := make(chan string)
 	go echoHelper(l, not)

--- a/util.go
+++ b/util.go
@@ -8,17 +8,17 @@ func (b *Bot) connectMessages() []*irc.Message {
 	messages := []*irc.Message{}
 	messages = append(messages, &irc.Message{
 		Command:  irc.USER,
-		Params:   []string{b.User, "0", "*"},
-		Trailing: b.User,
+		Params:   []string{b.user, "0", "*"},
+		Trailing: b.user,
 	})
 	messages = append(messages, &irc.Message{
 		Command: irc.NICK,
-		Params:  []string{b.OriginalName},
+		Params:  []string{b.name},
 	})
-	if b.Password != "" {
+	if b.password != "" {
 		messages = append(messages, &irc.Message{
 			Command: irc.PASS,
-			Params:  []string{b.Password},
+			Params:  []string{b.password},
 		})
 	}
 	return messages


### PR DESCRIPTION
Removes the wasted code around Classic, WithLogin, TLSWithLogin, etc. Two required params (a name and a server), and the rest are handled by config methods.

For #5 - what do you think @alaska