### PR TITLE
ircx: update config to use struct, clean up

### DIFF
--- a/bot_test.go
+++ b/bot_test.go
@@ -9,35 +9,33 @@ import (
 	"time"
 )
 
-func TestNewBot(t *testing.T) {
-	config := func(b *Bot) {
-		b.Server = "irc.example.org"
-		b.OriginalName = "test-bot"
-		b.User = "test-user"
-	}
+func TestNew(t *testing.T) {
 	wantOpts := map[string]bool{
 		"rejoin":    true,
 		"connected": true,
 	}
-	b := NewBot(config)
+	cfg := Config{
+		Options: wantOpts,
+		User:    "test-user",
+	}
+	b := New("irc.example.org", "test-bot", cfg)
 	if b.Server != "irc.example.org" {
 		t.Fatalf("Wanted server %s, got %s", "irc.example.org", b.Server)
 	}
 	if b.OriginalName != "test-bot" {
 		t.Fatalf("Wanted name %s, got %s", "test-bot", b.OriginalName)
 	}
-	if b.User != "test-user" {
-		t.Fatalf("Wanted user %s, got %s", "test-user", b.User)
+	if b.Config.User != "test-user" {
+		t.Fatalf("Wanted user %s, got %s", "test-user", b.Config.User)
 	}
-	if !reflect.DeepEqual(b.Options, wantOpts) {
-		t.Fatalf("Wanted config options %s, got %s", wantOpts, b.Options)
+	if !reflect.DeepEqual(b.Config.Options, wantOpts) {
+		t.Fatalf("Wanted config options %s, got %s", wantOpts, b.Config.Options)
 	}
 }
 
 func TestClassicHelper(t *testing.T) {
 	b := Classic("irc.example.org", "test-bot")
 	wantOpts := map[string]bool{
-		"rejoin":    true,
 		"connected": true,
 	}
 	if b.Server != "irc.example.org" {
@@ -46,18 +44,17 @@ func TestClassicHelper(t *testing.T) {
 	if b.OriginalName != "test-bot" {
 		t.Fatalf("Wanted name %s, got %s", "test-bot", b.OriginalName)
 	}
-	if b.User != "test-bot" {
-		t.Fatalf("Wanted user %s, got %s", "test-bot", b.User)
+	if b.Config.User != "test-bot" {
+		t.Fatalf("Wanted user %s, got %s", "test-bot", b.Config.User)
 	}
-	if !reflect.DeepEqual(b.Options, wantOpts) {
-		t.Fatalf("Wanted config options %s, got %s", wantOpts, b.Options)
+	if !reflect.DeepEqual(b.Config.Options, wantOpts) {
+		t.Fatalf("Wanted config options %s, got %s", wantOpts, b.Config.Options)
 	}
 }
 
 func TestPasswordHelper(t *testing.T) {
 	b := WithLogin("irc.example.org", "test-bot", "test-user", "test-password")
 	wantOpts := map[string]bool{
-		"rejoin":    true,
 		"connected": true,
 	}
 	if b.Server != "irc.example.org" {
@@ -66,14 +63,14 @@ func TestPasswordHelper(t *testing.T) {
 	if b.OriginalName != "test-bot" {
 		t.Fatalf("Wanted name %s, got %s", "test-bot", b.OriginalName)
 	}
-	if b.User != "test-user" {
-		t.Fatalf("Wanted user %s, got %s", "test-user", b.User)
+	if b.Config.User != "test-user" {
+		t.Fatalf("Wanted user %s, got %s", "test-user", b.Config.User)
 	}
-	if b.Password != "test-password" {
-		t.Fatalf("Wanted password %s, got %s", "test-password", b.Password)
+	if b.Config.Password != "test-password" {
+		t.Fatalf("Wanted password %s, got %s", "test-password", b.Config.Password)
 	}
-	if !reflect.DeepEqual(b.Options, wantOpts) {
-		t.Fatalf("Wanted config options %s, got %s", wantOpts, b.Options)
+	if !reflect.DeepEqual(b.Config.Options, wantOpts) {
+		t.Fatalf("Wanted config options %s, got %s", wantOpts, b.Config.Options)
 	}
 }
 

--- a/legacy.go
+++ b/legacy.go
@@ -1,0 +1,52 @@
+package ircx
+
+import (
+	"crypto/tls"
+)
+
+// Classic creates an instance of ircx poised to connect to the given server
+// with the given IRC name.
+func Classic(server string, name string) *Bot {
+	cfg := Config{
+		Options: map[string]bool{"connected": true},
+		User:    name,
+	}
+	return New(server, name, cfg)
+}
+
+func WithLogin(server string, name string, user string, password string) *Bot {
+	cfg := Config{
+		Options:  map[string]bool{"connected": true},
+		User:     user,
+		Password: password,
+	}
+
+	return New(server, name, cfg)
+}
+
+// WithTLS creates an instance of ircx poised to connect to the given server
+// using TLS with the given IRC name.
+func WithTLS(server string, name string, tlsConfig *tls.Config) *Bot {
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{}
+	}
+	cfg := Config{
+		Options:   map[string]bool{"connected": true},
+		TLSConfig: tlsConfig,
+		User:      name,
+	}
+	return New(server, name, cfg)
+}
+
+func WithLoginTLS(server string, name string, user string, password string, tlsConfig *tls.Config) *Bot {
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{}
+	}
+	cfg := Config{
+		Options:   map[string]bool{"connected": true},
+		TLSConfig: tlsConfig,
+		User:      user,
+		Password:  password,
+	}
+	return New(server, name, cfg)
+}

--- a/util.go
+++ b/util.go
@@ -8,17 +8,17 @@ func (b *Bot) connectMessages() []*irc.Message {
 	messages := []*irc.Message{}
 	messages = append(messages, &irc.Message{
 		Command:  irc.USER,
-		Params:   []string{b.User, "0", "*"},
-		Trailing: b.User,
+		Params:   []string{b.Config.User, "0", "*"},
+		Trailing: b.Config.User,
 	})
 	messages = append(messages, &irc.Message{
 		Command: irc.NICK,
 		Params:  []string{b.OriginalName},
 	})
-	if b.Password != "" {
+	if b.Config.Password != "" {
 		messages = append(messages, &irc.Message{
 			Command: irc.PASS,
-			Params:  []string{b.Password},
+			Params:  []string{b.Config.Password},
 		})
 	}
 	return messages


### PR DESCRIPTION
Hey @alaska (and anyone else), 

I had some spare time this weekend, so I decided to do a little pruning of `ircx`. This update keeps the legacy `Classic`, `WithLogin`, and TLS methods, but uses a `Config` struct and exposes a `New` that uses it. It's a bit of a breaking change, but 

It also cleans up some of the logic around retries.

Also addresses #8 