### PR TITLE
Send PASS before USER and NICK when connecting.

### DIFF
--- a/util.go
+++ b/util.go
@@ -6,20 +6,20 @@ import "github.com/sorcix/irc"
 // connect to the IRC server.
 func (b *Bot) connectMessages() []*irc.Message {
 	messages := []*irc.Message{}
-	messages = append(messages, &irc.Message{
-		Command:  irc.USER,
-		Params:   []string{b.User, "0", "*"},
-		Trailing: b.User,
-	})
-	messages = append(messages, &irc.Message{
-		Command: irc.NICK,
-		Params:  []string{b.OriginalName},
-	})
 	if b.Password != "" {
 		messages = append(messages, &irc.Message{
 			Command: irc.PASS,
 			Params:  []string{b.Password},
 		})
 	}
+	messages = append(messages, &irc.Message{
+		Command: irc.NICK,
+		Params:  []string{b.OriginalName},
+	})
+	messages = append(messages, &irc.Message{
+		Command:  irc.USER,
+		Params:   []string{b.User, "0", "*"},
+		Trailing: b.User,
+	})
 	return messages
 }


### PR DESCRIPTION
"The password can and must be set before any attempt to register the connection is made.  Currently this requires that clients send a PASS command before sending the NICK/USER combination..." -- https://tools.ietf.org/html/rfc1459#section-4.1.1