### PR TITLE
Expose sender so that it can be used without callbacks

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -18,7 +18,7 @@ type Bot struct {
 	Options      map[string]bool
 	Data         chan *irc.Message
 	tlsConfig    *tls.Config
-	sender       ServerSender
+	Sender       ServerSender
 	callbacks    map[string][]Callback
 	reader       *irc.Decoder
 	writer       *irc.Encoder
@@ -108,7 +108,7 @@ func (b *Bot) Connect() error {
 	b.conn = conn
 	b.reader = irc.NewDecoder(conn)
 	b.writer = irc.NewEncoder(conn)
-	b.sender = ServerSender{writer: &b.writer}
+	b.Sender = ServerSender{writer: &b.writer}
 	for _, msg := range b.connectMessages() {
 		err := b.writer.Encode(msg)
 		if err != nil {

--- a/callbacks.go
+++ b/callbacks.go
@@ -23,7 +23,7 @@ func (b *Bot) AddCallback(value string, c Callback) {
 		return
 	}
 	if c.Sender == nil {
-		c.Sender = b.sender // if no sender is specified, use default
+		c.Sender = b.Sender // if no sender is specified, use default
 	}
 	b.callbacks[value] = append(b.callbacks[value], c)
 }


### PR DESCRIPTION
Right now, the only way to send messages is when triggered via callbacks. A
bot may want to send messages in other situations, like when triggered via a
webhook.