### PR TITLE
ircx: remove logging, add error handling + better retry logic

### DIFF
--- a/bot_test.go
+++ b/bot_test.go
@@ -175,6 +175,7 @@ func TestReconnect(t *testing.T) {
 	}
 
 	b := Classic(l.Addr().String(), "test-bot")
+	b.Config.MaxRetries = 2
 
 	not := make(chan struct{})
 	go dcHelper(l, not)

--- a/callbacks.go
+++ b/callbacks.go
@@ -1,10 +1,12 @@
 package ircx
 
 import (
-	"log"
+	"errors"
 
 	"github.com/sorcix/irc"
 )
+
+var ErrInvalidHandler = errors.New("invalid handler specified for callback")
 
 // messageCallback is called on every message recieved from the IRC
 // server, checking to see if there are any actions that need to be performed
@@ -17,15 +19,15 @@ func (b *Bot) messageCallback(m *irc.Message) {
 }
 
 // AddCallback is used to add a callback method for a given action
-func (b *Bot) AddCallback(value string, c Callback) {
+func (b *Bot) AddCallback(value string, c Callback) error {
 	if c.Handler == nil {
-		log.Println("Ignoring nil handler for callback ", value)
-		return
+		return ErrInvalidHandler
 	}
 	if c.Sender == nil {
 		c.Sender = b.Sender // if no sender is specified, use default
 	}
 	b.callbacks[value] = append(b.callbacks[value], c)
+	return nil
 }
 
 // CallbackLoop reads from the ReadLoop channel and initiates a


### PR DESCRIPTION
Addresses #11

Removes all of the superfluous logging and returns errors instead. Also changes how the retry logic works -- instead of a config string, adds a `MaxRetries` in the `Config` struct, if it's set to above 0 it will try that many times before returning an error. 

cc @alaska and @mvdan -- this is a breaking API change, but I think it's worth it in the long run. 