### PR TITLE
ircx: don't launch each handler in a goroutine

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -37,7 +37,7 @@ func New(server, name string, config Config) *Bot {
 		Server:       server,
 		OriginalName: name,
 		Config:       config,
-		Data:         make(chan *irc.Message),
+		Data:         make(chan *irc.Message, 10), // buffer 10 messages
 		handlers:     make(map[string][]Handler),
 		tries:        0,
 	}
@@ -127,7 +127,7 @@ func (b *Bot) onMessage(m *irc.Message) {
 		return
 	}
 	for _, h := range handlers {
-		go h.Handle(b.Sender, m)
+		h.Handle(b.Sender, m)
 	}
 }
 


### PR DESCRIPTION
Launching every handler in a new goroutine can/will cause message's handlers to get scheduled out of order, causing side effects that may not be desired if the client is tracking IRC state. 

Instead, we handle them synchronously and rely on the handler to not block. It's not great, but there's no other way to guarantee that a client has processed one message before receiving another. 