### PR TITLE
Fix reconnecting, add logging

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -66,7 +66,7 @@ func (b *Bot) Connect() error {
 	b.conn = conn
 	b.reader = irc.NewDecoder(conn)
 	b.writer = irc.NewEncoder(conn)
-	b.Sender = serverSender{writer: b.writer, logger: b.log}
+	b.Sender = serverSender{writer: b.writer, logger: b.Logger}
 	for _, msg := range b.connectMessages() {
 		level.Debug(b.Logger()).Log("action", "send", "message", msg.String())
 		if err := b.writer.Encode(msg); err != nil {

--- a/sender.go
+++ b/sender.go
@@ -17,11 +17,11 @@ type Sender interface {
 type serverSender struct {
 	writer *irc.Encoder
 
-	logger log.Logger
+	logger func() log.Logger
 }
 
 // Send sends the specified message
 func (m serverSender) Send(msg *irc.Message) error {
-	level.Debug(m.logger).Log("action", "send", "message", msg.String())
+	level.Debug(m.logger()).Log("action", "send", "message", msg.String())
 	return m.writer.Encode(msg)
 }


### PR DESCRIPTION
It's come to my attention that reconnecting was not working properly for me. In the course of doing that, I took a stab at adding some optional logging. Because this is a library, the default behavior should be that there is no output at all, so the default logging implementation is merely a `noop`, which is only created once to avoid any performance issues.

If this breaks anyone's workflow or otherwise, please do let me know! I don't touch this very often (the first commit is 3 and a half years ago), but I am very around and happy to help.