### PR TITLE
fix crash: skip invalid messages

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -144,6 +144,9 @@ func (b *Bot) ReadLoop() error {
 			level.Error(b.Logger()).Log("action", "readloop", "error", err)
 			return b.Reconnect()
 		}
+		if msg == nil {
+			continue // invalid message
+		}
 		level.Debug(b.log).Log("action", "read", "message", msg.String())
 		b.Data <- msg
 	}


### PR DESCRIPTION
As per https://godoc.org/github.com/sorcix/irc#ParseMessage, ParseMessage
returns nil if the message is invalid.

possibly related to #26