### PR TITLE
convert to a Go module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,12 @@
 language: go
 
 go:
-  - "1.10.x"
+  - "1.11.x"
+
+env:
+  - GO111MODULE=on
+
+install: true
+
+script:
+  - go test ./...

--- a/bot.go
+++ b/bot.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/sorcix/irc"
+	"gopkg.in/sorcix/irc.v1"
 )
 
 var defaultLogger = log.NewNopLogger()

--- a/bot.go
+++ b/bot.go
@@ -147,7 +147,7 @@ func (b *Bot) ReadLoop() error {
 		if msg == nil {
 			continue // invalid message
 		}
-		level.Debug(b.log).Log("action", "read", "message", msg.String())
+		level.Debug(b.Logger()).Log("action", "read", "message", msg.String())
 		b.Data <- msg
 	}
 }

--- a/example/main.go
+++ b/example/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 
 	"github.com/nickvanw/ircx"
-	"github.com/sorcix/irc"
+	"gopkg.in/sorcix/irc.v1"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/nickvanw/ircx
+
+go 1.10
+
+require (
+	github.com/go-kit/kit v0.8.0
+	github.com/go-logfmt/logfmt v0.4.0 // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/sorcix/irc v1.1.4
+)

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/go-kit/kit v0.8.0
 	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
-	github.com/sorcix/irc v1.1.4
+	gopkg.in/sorcix/irc.v1 v1.1.4
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/go-kit/kit v0.8.0 h1:Wz+5lgoB0kkuqLEc6NVmwRknTKP6dTGbSqvhZtBI/j0=
+github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/go-logfmt/logfmt v0.4.0 h1:MP4Eh7ZCb31lleYCFuwm0oe4/YGak+5l1vA2NOE80nA=
+github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
+github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj2vyii2bbUNDw3kt9VxK2EY=
+github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/sorcix/irc v1.1.4 h1:KDmVMPPzK4kbf3TQw1RsZAqTsh2JL9Zw69hYduX9Ykw=
+github.com/sorcix/irc v1.1.4/go.mod h1:MhzbySH63tDknqfvAAFK3ps/942g4z9EeJ/4lGgHyZc=

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,5 @@ github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj2vyii2bbUNDw3kt9VxK2EY=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
-github.com/sorcix/irc v1.1.4 h1:KDmVMPPzK4kbf3TQw1RsZAqTsh2JL9Zw69hYduX9Ykw=
-github.com/sorcix/irc v1.1.4/go.mod h1:MhzbySH63tDknqfvAAFK3ps/942g4z9EeJ/4lGgHyZc=
+gopkg.in/sorcix/irc.v1 v1.1.4 h1:ejxu1vDyqn1d+I5WXzh93pMDq5NqdwBl3V/eN5c2we8=
+gopkg.in/sorcix/irc.v1 v1.1.4/go.mod h1:CHwY3DGuZpB6/OvF+fj4Jlvnj6QeS56EUTDoQkuAePM=

--- a/sender.go
+++ b/sender.go
@@ -3,7 +3,7 @@ package ircx
 import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/sorcix/irc"
+	"gopkg.in/sorcix/irc.v1"
 )
 
 // Sender is an interface for sending IRC messages

--- a/tls_test.go
+++ b/tls_test.go
@@ -25,9 +25,9 @@ func TestTLSConnect(t *testing.T) {
 		NotAfter:              time.Now().AddDate(10, 0, 0),
 		SubjectKeyId:          []byte{1, 2, 3, 4, 5},
 		BasicConstraintsValid: true,
-		IsCA:        true,
-		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 	}
 
 	priv, _ := rsa.GenerateKey(rand.Reader, 1024)


### PR DESCRIPTION
And update CI to Go 1.11 with GO111MODULE=on. 'go get' is no longer
needed on CI, so remove the install step.

While at it, gofmt.